### PR TITLE
Update Default API Base URL to Exclude Location

### DIFF
--- a/automation/cse/cse_insights_update/cse_insights_update.py
+++ b/automation/cse/cse_insights_update/cse_insights_update.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
     if args.env:
         SUMO_API_URL =  "https://api.{}.sumologic.com/api/".format(args.env[0])
     else:
-        SUMO_API_URL =  "https://api.us2.sumologic.com/api/"
+        SUMO_API_URL =  "https://api.sumologic.com/api/"
 
     # Insights configuration
     INSIGHTS_FILTER = args.filter[0] 


### PR DESCRIPTION
DESC: As per the docs, when you setup a token on US1 and need to use the US1 API instance, you don't specify a location. Apparently specifying us1 will not work.

REL DOCS:
* https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-by-Deployment-and-Firewall-Security
* https://api.us2.sumologic.com/docs/sec/